### PR TITLE
Fix condition for ignoring assay_tiledb_group

### DIFF
--- a/src/cellarr/CellArrDataset.py
+++ b/src/cellarr/CellArrDataset.py
@@ -155,7 +155,7 @@ class CellArrDataset:
         # TODO: Maybe switch to on-demand loading of these objects
         self._matrix_tdb = {}
         _asy_path = dataset_path
-        if assay_tiledb_group is not None or len(assay_tiledb_group) > 0:
+        if assay_tiledb_group is not None and len(assay_tiledb_group) > 0:
             _asy_path = f"{dataset_path}/{assay_tiledb_group}"
         for mtdb in assay_uri:
             self._matrix_tdb[mtdb] = tiledb.open(f"{_asy_path}/{mtdb}", "r", ctx=ctx)


### PR DESCRIPTION
Currently, [the condition to append the `assay_tiledb_group` to `_asy_path`](https://github.com/TileOme/cellarr/blob/7a08b2aba4e26d1f83b3042fc0cb870a1fa566a9/src/cellarr/CellArrDataset.py#L158) is
```python
if assay_tiledb_group is not None or len(assay_tiledb_group) > 0
```
This is incorrect, because 
 1. this evaluates to `True` for empty string because `assay_tiledb_group is not None` evaluates to `True`
 2. raises an exception for `None` because you cannot call `len(None)`

Instead, the condition should be changed to
```
if assay_tiledb_group is not None and len(assay_tiledb_group) > 0
```

This pull request adds the proposed fix.

## Minimal Example
```python
from pathlib import Path

import numpy as np
import tiledb
from cellarr import CellArrDataset

data = np.arange(3).astype(float)[:, np.newaxis]
prefix = "blub"
Path(prefix).mkdir(exist_ok=True, parents=True)
tiledb.from_numpy(f"{prefix}/counts", data)
tiledb.from_numpy(f"{prefix}/gene_annotation", np.asarray([[1]]))
tiledb.from_numpy(f"{prefix}/cell_metadata", data)
tiledb.from_numpy(f"{prefix}/sample_metadata", np.ones_like(data))
ds = CellArrDataset(dataset_path=prefix, assay_tiledb_group=None)
print(f"{ds=}")
```
### Without Fix
Output of minimal example:
```
Traceback (most recent call last):
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/example.py", line 14, in <module>
    ds = CellArrDataset(dataset_path=prefix, assay_tiledb_group=None)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/src/cellarr/CellArrDataset.py", line 158, in __init__
    if assay_tiledb_group is not None or len(assay_tiledb_group) > 0:
                                         ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```


### With Fix
Output of minimal example:
```
ds=CellArrDataset(number_of_rows=3, number_of_columns=1, at path=blub)
```