### PR TITLE
Add option to pass tiledb.Ctx object instead of tiledb.Config

### DIFF
--- a/src/cellarr/CellArrDataset.py
+++ b/src/cellarr/CellArrDataset.py
@@ -104,7 +104,7 @@ class CellArrDataset:
         gene_annotation_uri: str = "gene_annotation",
         cell_metadata_uri: str = "cell_metadata",
         sample_metadata_uri: str = "sample_metadata",
-        config: tiledb.Config = None,
+        config: tiledb.Config | tiledb.Ctx | None = None,
     ):
         """Initialize a ``CellArrDataset``.
 
@@ -141,12 +141,15 @@ class CellArrDataset:
                 Relative path to sample metadata store.
 
             config:
-                Custom TileDB configuration. If None, defaults will be used.
+                Custom TileDB configuration or context. If None, defaults will be used.
         """
         if config is None:
             config = tiledb.Config()
-
-        ctx = tiledb.Ctx(config)
+        if isinstance(config, tiledb.Config):
+            ctx = tiledb.Ctx(config)
+        else:
+            assert isinstance(config, tiledb.Ctx)
+            ctx = config
 
         self._dataset_path = dataset_path
 


### PR DESCRIPTION
I would like to use cellarr for a unified data structure that can operate both on in-memory data and data that is streamed from disk. To be able to use in-memory data, I need to be able to pass the `tiledb.Ctx` that holds the in-memory arrays into the `CellArrDataset`. This PR adds a proposal to implement htis reuqirement for using `mem://` url for dataset, which allows for easy import from np.ndarray.

I use this sample script `example-ctx-passed.py`:
```python
import argparse
from pathlib import Path

import numpy as np
import tiledb
from cellarr import CellArrDataset

parser = argparse.ArgumentParser()
parser.add_argument("--with-ctx", required=False, action="store_true")
args = parser.parse_args()

if args.with_ctx:
    ctx = tiledb.Ctx()
else:
    ctx = None
data = np.arange(3).astype(float)[:, np.newaxis]
prefix = "mem://blub"
atg = "group"
tiledb.from_numpy(f"{prefix}/{atg}/counts", data, ctx=ctx)
tiledb.from_numpy(f"{prefix}/gene_annotation", np.asarray([[1]]), ctx=ctx)
tiledb.from_numpy(f"{prefix}/cell_metadata", data, ctx=ctx)
tiledb.from_numpy(f"{prefix}/sample_metadata", np.ones_like(data), ctx=ctx)
ds = CellArrDataset(dataset_path=prefix, assay_tiledb_group=atg, config=ctx)
print(f"{ds=}")
```
and use it on master and my PR branch, respectively:

### Master
```
$ python example-ctx-passed.py           
Traceback (most recent call last):
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/example-ctx-passed.py", line 23, in <module>
    ds = CellArrDataset(dataset_path=prefix, assay_tiledb_group=atg, config=ctx)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/src/cellarr/CellArrDataset.py", line 161, in __init__
    self._matrix_tdb[mtdb] = tiledb.open(f"{_asy_path}/{mtdb}", "r", ctx=ctx)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/.venv/lib/python3.12/site-packages/tiledb/highlevel.py", line 27, in open
    return tiledb.Array.load_typed(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/.venv/lib/python3.12/site-packages/tiledb/array.py", line 422, in load_typed
    tmp_array = preload_array(uri, mode, key, timestamp, ctx)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zottel/workspace/cellarr-bugfix/cellarr/.venv/lib/python3.12/site-packages/tiledb/array.py", line 300, in preload_array
    return lt.Array(ctx, uri, query_type, (ts_start, ts_end))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tiledb.libtiledb.TileDBError: [TileDB::Array] Error: Cannot open array; Array does not exist.
```

### PR Branch
```
$ python example-ctx-passed.py --with-ctx
ds=CellArrDataset(number_of_rows=3, number_of_columns=1, at path=mem://blub)
```

I do not know if this is the best solution, but it works